### PR TITLE
fix(fan): add pwm fallback for custom fan targets

### DIFF
--- a/scripts/tests/test_fan_service.py
+++ b/scripts/tests/test_fan_service.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.join(REPO_ROOT, "src", "daemon"))
+
+gi = types.ModuleType("gi")
+gi.repository = types.ModuleType("gi.repository")
+gi.repository.GLib = types.SimpleNamespace(MainLoop=lambda: None)
+sys.modules.setdefault("gi", gi)
+sys.modules.setdefault("gi.repository", gi.repository)
+sys.modules.setdefault("pydbus", types.SimpleNamespace(SystemBus=lambda: None))
+
+from services import fan_service
+
+
+class FanControllerSysfsTest(unittest.TestCase):
+    def make_controller(self, hwmon_path, fans=(1, 2), max_speed=6000):
+        controller = fan_service.FanController.__new__(fan_service.FanController)
+        controller.hwmon_path = hwmon_path
+        controller.found_fans = list(fans)
+        controller.fan_count = len(fans)
+        controller.max_speeds = {fan: max_speed for fan in fans}
+        controller.mode = "custom"
+        controller._fallback_paths = {}
+        return controller
+
+    def write_file(self, directory, name, value="0"):
+        path = os.path.join(directory, name)
+        with open(path, "w") as handle:
+            handle.write(str(value))
+        return path
+
+    def read_file(self, directory, name):
+        with open(os.path.join(directory, name)) as handle:
+            return handle.read()
+
+    def test_existing_fan_target_file_wins_over_pwm_fallback(self):
+        with tempfile.TemporaryDirectory() as hwmon:
+            self.write_file(hwmon, "pwm1", "0")
+            self.write_file(hwmon, "fan1_target", "0")
+            controller = self.make_controller(hwmon, fans=(1,))
+
+            self.assertTrue(controller.set_fan_target(1, 3000))
+
+            self.assertEqual(self.read_file(hwmon, "fan1_target"), "3000")
+            self.assertEqual(self.read_file(hwmon, "pwm1"), "0")
+
+    def test_pwm_fallback_maps_rpm_to_pwm_when_target_file_missing(self):
+        with tempfile.TemporaryDirectory() as hwmon:
+            self.write_file(hwmon, "pwm1", "0")
+            self.write_file(hwmon, "pwm1_enable", "1")
+            controller = self.make_controller(hwmon, fans=(1,), max_speed=6000)
+
+            self.assertTrue(controller.set_fan_target(1, 6000))
+
+            self.assertEqual(self.read_file(hwmon, "pwm1"), "255")
+
+    def test_pwm_fallback_clamps_nonzero_pwm_to_safe_minimum(self):
+        with tempfile.TemporaryDirectory() as hwmon:
+            self.write_file(hwmon, "pwm1", "0")
+            self.write_file(hwmon, "pwm1_enable", "1")
+            controller = self.make_controller(hwmon, fans=(1,), max_speed=6000)
+
+            self.assertTrue(controller.set_fan_target(1, 1000))
+
+            self.assertEqual(self.read_file(hwmon, "pwm1"), "220")
+
+    def test_pwm_fallback_preserves_zero_pwm(self):
+        with tempfile.TemporaryDirectory() as hwmon:
+            self.write_file(hwmon, "pwm1", "255")
+            self.write_file(hwmon, "pwm1_enable", "1")
+            controller = self.make_controller(hwmon, fans=(1,), max_speed=6000)
+
+            self.assertTrue(controller.set_fan_target(1, 0))
+
+            self.assertEqual(self.read_file(hwmon, "pwm1"), "0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/daemon/services/fan_service.py
+++ b/src/daemon/services/fan_service.py
@@ -22,6 +22,9 @@ from common.dbus_helpers import run_service, system_sleeping
 
 logger = setup_logging("fan")
 
+PWM_MAX = 255
+PWM_FALLBACK_MIN = 220
+
 # ─── Fan Controller ───────────────────────────────────────────────────────────
 
 
@@ -139,7 +142,15 @@ class FanController:
         return 0
 
     def get_target_speed(self, fan_num):
-        return self._hwmon_read(f"fan{fan_num}_target")
+        target_path = os.path.join(self.hwmon_path, f"fan{fan_num}_target") if self.hwmon_path else None
+        if target_path and sysfs_exists(target_path):
+            return sysfs_read(target_path)
+
+        if self._has_pwm_fallback():
+            pwm = self._hwmon_read("pwm1")
+            return int(self.get_max_speed(fan_num) * pwm / PWM_MAX)
+
+        return 0
 
     # ── write ─────────────────────────────────────────────────────────
 
@@ -179,10 +190,43 @@ class FanController:
             return False
         rpm = max(0, min(rpm, self.get_max_speed(fan_num)))
         path = os.path.join(self.hwmon_path, f"fan{fan_num}_target")
-        ok = sysfs_write(path, rpm)
+        if sysfs_exists(path):
+            ok = sysfs_write(path, rpm)
+        elif self._has_pwm_fallback():
+            ok = self._set_pwm_fallback_target(fan_num, rpm)
+        else:
+            logger.warning(
+                "No fan%d_target or pwm1 fallback available under %s",
+                fan_num,
+                self.hwmon_path,
+            )
+            return False
+
         if ok:
             logger.info("Fan %d target set to %d RPM", fan_num, rpm)
         return ok
+
+    def _has_pwm_fallback(self):
+        if not self.hwmon_path:
+            return False
+        return sysfs_exists(os.path.join(self.hwmon_path, "pwm1"))
+
+    def _set_pwm_fallback_target(self, fan_num, rpm):
+        max_speed = self.get_max_speed(fan_num)
+        if max_speed <= 0:
+            max_speed = 6000
+
+        pwm = int(round(rpm * PWM_MAX / max_speed))
+        pwm = max(0, min(pwm, PWM_MAX))
+        if pwm > 0:
+            pwm = max(pwm, PWM_FALLBACK_MIN)
+
+        enable_path = os.path.join(self.hwmon_path, "pwm1_enable")
+        if sysfs_exists(enable_path) and self.get_mode() != "custom":
+            if not self.set_mode("custom"):
+                return False
+
+        return sysfs_write(os.path.join(self.hwmon_path, "pwm1"), pwm)
 
     def is_available(self):
         return self.hwmon_path is not None and self.fan_count > 0


### PR DESCRIPTION
## Summary

- keep existing fanN_target RPM writes when target files are exposed
- add pwm1 fallback for hp-wmi hwmon devices that expose PWM control but no fanN_target files
- clamp nonzero PWM fallback requests to 220, based on hardware validation where lower values are rejected/read back as 0
- add unit tests for target-file priority, PWM fallback mapping, minimum clamp, and zero preservation

## Validation

- Tested custom fan mode in the GUI on a pwm1-only HP hwmon laptop
- python3 -m unittest scripts.tests.test_fan_service
- python3 -m py_compile src/daemon/services/fan_service.py scripts/tests/test_fan_service.py
- git diff --check

Closes #65