### PR TITLE
Add test script and troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ cd OmenCommandCenterforLinux
 sudo ./setup.sh uninstall
 ```
 
+## 🐛 Troubleshooting
+
+If the `omen` CLI fails with a `pydbus` import error, your `PATH` may be pointing to a non-system Python (e.g., Conda) that does not share packages with the system Python where `python3-pydbus` was installed. See [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md) for the fix.
+
 ## 🐧 Compatibility
 
 | Distribution | Status | Notes |

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,40 @@
+# Troubleshooting
+
+## `omen` CLI fails with `ModuleNotFoundError: No module named 'pydbus'`
+
+### Symptom
+
+```bash
+$ omen fan auto
+Traceback (most recent call last):
+  File "/usr/bin/omen", line 4, in <module>
+    from pydbus import SystemBus
+ModuleNotFoundError: No module named 'pydbus'
+```
+
+### Root Cause
+
+Your `PATH` may prioritize a non-system Python interpreter — commonly a Conda or virtual-environment installation — that does not share packages with the system Python. The project uses `#!/usr/bin/env python3` in its installed scripts, which picks whichever `python3` is first in `PATH` rather than the system one where `python3-pydbus` was installed by the package manager.
+
+### Fix
+
+Update the installed scripts to use the system Python directly:
+
+```bash
+sudo sed -i '1s|#!/usr/bin/env python3|#!/usr/bin/python3|' /usr/bin/omen
+sudo sed -i 's|exec python3 |exec /usr/bin/python3 |' /usr/bin/hp-manager
+```
+
+### Verification
+
+```bash
+head -n 1 /usr/bin/omen
+# Expected: #!/usr/bin/python3
+
+omen fan auto
+# Expected: Fan mode set to auto: OK
+```
+
+### Permanent Fix
+
+If you reinstall or update via `setup.sh`, the scripts may be overwritten and revert to `#!/usr/bin/env python3`. Re-apply the fix after each update, or modify `src/omen-cli.py` and the GUI launcher in the source tree before running `setup.sh`.

--- a/test-omen-cli.sh
+++ b/test-omen-cli.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Test script for OMEN Command Center CLI
+# Usage: ./test-omen-cli.sh
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+run_test() {
+    local label=$1
+    shift
+    if "$@" > /dev/null 2>&1; then
+        printf "  [PASS] %s\n" "$label"
+        ((PASS++)) || true
+    else
+        printf "  [FAIL] %s\n" "$label"
+        ((FAIL++)) || true
+    fi
+}
+
+echo "=== OMEN CLI Service Tests ==="
+echo ""
+
+# --- Fan tests ---
+echo "Fan tests:"
+run_test "fan max"  omen fan max
+run_test "fan auto" omen fan auto
+
+# --- Power mode tests ---
+echo ""
+echo "Power mode tests:"
+run_test "mode performance" omen mode performance
+run_test "mode balanced"    omen mode balanced
+run_test "mode quiet"       omen mode quiet
+run_test "mode eco"         omen mode eco
+
+# --- MUX tests ---
+echo ""
+echo "MUX tests:"
+run_test "mux hybrid"   omen mux hybrid
+run_test "mux discrete" omen mux discrete
+
+# --- Service health ---
+echo ""
+echo "D-Bus service health:"
+run_test "dbus fan service"    /usr/bin/python3 -c "from pydbus import SystemBus; SystemBus().get('com.yyl.hpmanager.fan')"
+run_test "dbus power service"  /usr/bin/python3 -c "from pydbus import SystemBus; SystemBus().get('com.yyl.hpmanager.power')"
+run_test "dbus rgb service"    /usr/bin/python3 -c "from pydbus import SystemBus; SystemBus().get('com.yyl.hpmanager.rgb')"
+run_test "dbus mux service"    /usr/bin/python3 -c "from pydbus import SystemBus; SystemBus().get('com.yyl.hpmanager.mux')"
+run_test "dbus platform svc"   /usr/bin/python3 -c "from pydbus import SystemBus; SystemBus().get('com.yyl.hpmanager.platform')"
+
+# --- Summary ---
+echo ""
+echo "=== Results ==="
+printf "  Passed: %d\n" "$PASS"
+printf "  Failed: %d\n" "$FAIL"
+
+if [ "$FAIL" -eq 0 ]; then
+    echo "  All tests passed."
+    exit 0
+else
+    echo "  Some tests failed — check individual service logs with:"
+    echo "    journalctl -u hpm-fan.service -u hpm-power.service --since '5 minutes ago'"
+    exit 1
+fi


### PR DESCRIPTION
## Changes

- **test-omen-cli.sh**: A shell script to verify all CLI commands and D-Bus service health end-to-end.
- **TROUBLESHOOTING.md**: Documents the "pydbus not found" error caused by non-system Python (e.g., Conda) being first in PATH, including the sed one-liner fix.
- **README.md**: Adds a Troubleshooting section linking to TROUBLESHOOTING.md.

Co-Authored-By: Oz <oz-agent@warp.dev>