### PR TITLE
test: ilgisiz sıcaklık sensörlerinin maksimum fanı tetiklemesini önle

### DIFF
--- a/src/daemon/services/fan_service.py
+++ b/src/daemon/services/fan_service.py
@@ -33,6 +33,10 @@ PWM_MAX = 255
 PWM_FALLBACK_MIN = 50
 THERMAL_PROFILE_BALANCED = 0
 THERMAL_PROFILE_MAX = 1
+THERMAL_PROTECTION_TRIGGER_C = 95.0
+THERMAL_PROTECTION_RELEASE_C = 85.0
+THERMAL_PROTECTION_TIMEOUT_S = 300.0
+THERMAL_PROTECTION_TIMEOUT_RELEASE_C = 90.0
 
 # ─── Fan Controller ───────────────────────────────────────────────────────────
 
@@ -527,6 +531,23 @@ class FanService:
                 return f0 + (f1 - f0) * ratio
         return points[-1][1]
 
+    @staticmethod
+    def _should_exit_thermal_protection(temp, elapsed):
+        """Return whether thermal protection can safely release.
+
+        The lower release threshold provides hysteresis so the fan mode does
+        not rapidly toggle around the trigger temperature.  The timeout path
+        is a safety net for sensors that cool slowly but remain below the
+        trigger point.
+        """
+        return (
+            temp <= THERMAL_PROTECTION_RELEASE_C
+            or (
+                elapsed > THERMAL_PROTECTION_TIMEOUT_S
+                and temp <= THERMAL_PROTECTION_TIMEOUT_RELEASE_C
+            )
+        )
+
     def _monitor_loop(self):
         while True:
             if system_sleeping.is_set():
@@ -543,7 +564,7 @@ class FanService:
                     fans_stalled = True
 
             # Thermal Protection Mode
-            if (temp > 95.0 or fans_stalled) and not self._thermal_protection_active:
+            if (temp > THERMAL_PROTECTION_TRIGGER_C or fans_stalled) and not self._thermal_protection_active:
                 if fans_stalled:
                     logger.critical("FAN STALL DETECTED! Temp is %d°C but fans are at 0 RPM! Activating Protection.", temp)
                 else:
@@ -563,10 +584,10 @@ class FanService:
                 # Exit conditions:
                 # 1. Temperature dropped below 85°C (10°C hysteresis from 95°C entry), OR
                 # 2. Protection active >5 minutes AND temp below 90°C (timeout safety net)
-                should_exit = temp <= 85.0 or (elapsed > 300.0 and temp <= 90.0)
+                should_exit = self._should_exit_thermal_protection(temp, elapsed)
 
                 if should_exit:
-                    if elapsed > 300.0:
+                    if elapsed > THERMAL_PROTECTION_TIMEOUT_S:
                         logger.info("Thermal Protection timeout after %.0fs (temp=%d°C). Deactivating.", elapsed, temp)
                     else:
                         logger.info("Temperature dropped to %d°C. Deactivating Thermal Protection Mode.", temp)

--- a/tests/test_fan_service.py
+++ b/tests/test_fan_service.py
@@ -6,7 +6,7 @@ import unittest
 from unittest import mock
 
 
-REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(REPO_ROOT, "src", "daemon"))
 
 gi = types.ModuleType("gi")
@@ -17,6 +17,7 @@ sys.modules.setdefault("gi.repository", gi.repository)
 sys.modules.setdefault("pydbus", types.SimpleNamespace(SystemBus=lambda: None))
 
 from services import fan_service
+from common import sysfs as sysfs_helpers
 
 
 class FanControllerSysfsTest(unittest.TestCase):
@@ -28,6 +29,7 @@ class FanControllerSysfsTest(unittest.TestCase):
         controller.max_speeds = {fan: max_speed for fan in fans}
         controller.mode = "custom"
         controller._fallback_paths = {}
+        controller._last_targets = {}
         return controller
 
     def write_file(self, directory, name, value="0"):
@@ -40,13 +42,21 @@ class FanControllerSysfsTest(unittest.TestCase):
         with open(os.path.join(directory, name)) as handle:
             return handle.read()
 
+    def allow_test_sysfs(self, directory):
+        return mock.patch.object(
+            sysfs_helpers,
+            "_ALLOWED_PREFIXES",
+            (os.path.realpath(directory) + os.sep,),
+        )
+
     def test_existing_fan_target_file_wins_over_pwm_fallback(self):
         with tempfile.TemporaryDirectory() as hwmon:
             self.write_file(hwmon, "pwm1", "0")
             self.write_file(hwmon, "fan1_target", "0")
             controller = self.make_controller(hwmon, fans=(1,))
 
-            self.assertTrue(controller.set_fan_target(1, 3000))
+            with self.allow_test_sysfs(hwmon):
+                self.assertTrue(controller.set_fan_target(1, 3000))
 
             self.assertEqual(self.read_file(hwmon, "fan1_target"), "3000")
             self.assertEqual(self.read_file(hwmon, "pwm1"), "0")
@@ -57,7 +67,8 @@ class FanControllerSysfsTest(unittest.TestCase):
             self.write_file(hwmon, "pwm1_enable", "1")
             controller = self.make_controller(hwmon, fans=(1,), max_speed=6000)
 
-            self.assertTrue(controller.set_fan_target(1, 6000))
+            with self.allow_test_sysfs(hwmon):
+                self.assertTrue(controller.set_fan_target(1, 6000))
 
             self.assertEqual(self.read_file(hwmon, "pwm1"), "255")
 
@@ -67,9 +78,13 @@ class FanControllerSysfsTest(unittest.TestCase):
             self.write_file(hwmon, "pwm1_enable", "1")
             controller = self.make_controller(hwmon, fans=(1,), max_speed=6000)
 
-            self.assertTrue(controller.set_fan_target(1, 1000))
+            with self.allow_test_sysfs(hwmon):
+                self.assertTrue(controller.set_fan_target(1, 1000))
 
-            self.assertEqual(self.read_file(hwmon, "pwm1"), "220")
+            self.assertEqual(
+                self.read_file(hwmon, "pwm1"),
+                str(fan_service.PWM_FALLBACK_MIN),
+            )
 
     def test_pwm_fallback_preserves_zero_pwm(self):
         with tempfile.TemporaryDirectory() as hwmon:
@@ -77,11 +92,12 @@ class FanControllerSysfsTest(unittest.TestCase):
             self.write_file(hwmon, "pwm1_enable", "1")
             controller = self.make_controller(hwmon, fans=(1,), max_speed=6000)
 
-            self.assertTrue(controller.set_fan_target(1, 0))
+            with self.allow_test_sysfs(hwmon):
+                self.assertTrue(controller.set_fan_target(1, 0))
 
             self.assertEqual(self.read_file(hwmon, "pwm1"), "0")
 
-    def test_read_current_mode_uses_thermal_profile_fallback_for_max(self):
+    def test_auto_pwm_mode_is_not_overridden_by_thermal_profile(self):
         controller = self.make_controller("/fake/hwmon", fans=(1,))
         def read_side_effect(path, default=0):
             if path.endswith("pwm1_enable"):
@@ -95,9 +111,9 @@ class FanControllerSysfsTest(unittest.TestCase):
              mock.patch.object(fan_service, "sysfs_exists", side_effect=exists_side_effect), \
              mock.patch.object(fan_service, "sysfs_read_str", return_value="balanced"):
             controller._read_current_mode()
-        self.assertEqual(controller.mode, "max")
+        self.assertEqual(controller.mode, "auto")
 
-    def test_read_current_mode_uses_platform_profile_fallback_for_max(self):
+    def test_auto_pwm_mode_is_not_overridden_by_platform_profile(self):
         controller = self.make_controller("/fake/hwmon", fans=(1,))
         def read_side_effect(path, default=0):
             if path.endswith("pwm1_enable"):
@@ -111,7 +127,24 @@ class FanControllerSysfsTest(unittest.TestCase):
              mock.patch.object(fan_service, "sysfs_exists", side_effect=exists_side_effect), \
              mock.patch.object(fan_service, "sysfs_read_str", return_value="performance"):
             controller._read_current_mode()
-        self.assertEqual(controller.mode, "max")
+        self.assertEqual(controller.mode, "auto")
+
+
+class ThermalProtectionTest(unittest.TestCase):
+    def test_releases_after_temperature_drops_below_hysteresis_threshold(self):
+        self.assertTrue(
+            fan_service.FanService._should_exit_thermal_protection(84.9, 10.0)
+        )
+
+    def test_stays_active_between_release_and_trigger_thresholds(self):
+        self.assertFalse(
+            fan_service.FanService._should_exit_thermal_protection(89.0, 10.0)
+        )
+
+    def test_timeout_releases_a_slow_cooling_sensor(self):
+        self.assertTrue(
+            fan_service.FanService._should_exit_thermal_protection(89.0, 301.0)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_hwmon_controller.py
+++ b/tests/test_hwmon_controller.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(REPO_ROOT, "src", "daemon"))
+
+from common import hwmon_controller
+
+
+class HwMonSensorSelectionTest(unittest.TestCase):
+    def write_sensor(self, root, index, name, temperatures):
+        directory = os.path.join(root, f"hwmon{index}")
+        os.makedirs(directory)
+        with open(os.path.join(directory, "name"), "w") as handle:
+            handle.write(name)
+        for sensor_index, temperature in enumerate(temperatures, start=1):
+            with open(
+                os.path.join(directory, f"temp{sensor_index}_input"), "w"
+            ) as handle:
+                handle.write(str(temperature))
+
+    def test_nvme_sensor_does_not_drive_cpu_or_gpu_temperature(self):
+        with tempfile.TemporaryDirectory() as directory:
+            hwmon_root = os.path.join(directory, "hwmon")
+            thermal_root = os.path.join(directory, "thermal")
+            os.makedirs(hwmon_root)
+            os.makedirs(thermal_root)
+
+            self.write_sensor(hwmon_root, 0, "k10temp", [42000])
+            self.write_sensor(hwmon_root, 1, "nvme", [35000, 99000])
+            self.write_sensor(hwmon_root, 2, "amdgpu", [45000])
+
+            with mock.patch.object(hwmon_controller, "HWMON_PATH", hwmon_root), \
+                 mock.patch.object(hwmon_controller, "THERMAL_ZONE_PATH", thermal_root):
+                controller = hwmon_controller.LinuxHwMonController()
+
+            self.assertEqual(controller.get_cpu_temperature(), 42.0)
+            self.assertEqual(controller.get_gpu_temperature(), 45.0)
+            self.assertEqual(controller.available_sensor_count, 2)
+
+    def test_invalid_absolute_zero_sensor_is_ignored(self):
+        with tempfile.TemporaryDirectory() as directory:
+            sensor = os.path.join(directory, "temp1_input")
+            with open(sensor, "w") as handle:
+                handle.write("-273000")
+
+            controller = hwmon_controller.LinuxHwMonController.__new__(
+                hwmon_controller.LinuxHwMonController
+            )
+            self.assertIsNone(controller._read_temperature_file(sensor))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mux_service.py
+++ b/tests/test_mux_service.py
@@ -1,37 +1,46 @@
+import glob
 import os
 import sys
 import unittest
 from unittest import mock
 
 
-REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(REPO_ROOT, "src", "daemon"))
 
 from services import mux_service
 
 
-class MUXControllerTest(unittest.TestCase):
-    def test_detect_backend_prefers_envycontrol(self):
-        with mock.patch.object(mux_service.shutil, "which", side_effect=lambda cmd: f"/usr/bin/{cmd}"):
-            ctrl = mux_service.MUXController()
-            ctrl.detect_backend("auto")
-        self.assertEqual(ctrl.get_backend(), "envycontrol")
+class NativeWmiMuxControllerTest(unittest.TestCase):
+    def test_native_backend_is_available_when_wmi_path_exists(self):
+        controller = mux_service.NativeWmiMuxController()
+        with mock.patch.object(mux_service, "sysfs_exists", return_value=True):
+            self.assertTrue(controller.is_available())
+            self.assertEqual(controller.get_backend(), "wmi-native")
 
-    def test_get_mode_normalizes_envycontrol_query_output(self):
-        ctrl = mux_service.MUXController.__new__(mux_service.MUXController)
-        ctrl.backend = "envycontrol"
-        ctrl.envycontrol = "/usr/bin/envycontrol"
-        ctrl.supergfxctl = None
-        ctrl.prime_select = None
-        ctrl._cached_mode = "unknown"
-        ctrl._last_check = 0.0
-        with mock.patch.object(mux_service.subprocess, "check_output", return_value=b"Current mode: Hybrid\n"):
-            self.assertEqual(ctrl.get_mode(), "hybrid")
-
-    def test_normalize_mode_handles_nvidia_offload_as_hybrid(self):
-        self.assertEqual(
-            mux_service.MUXController._normalize_mode("nvidia-offload"),
-            "hybrid",
+    def test_get_mode_detects_hybrid_from_pci_devices(self):
+        controller = mux_service.NativeWmiMuxController()
+        lspci_output = (
+            "0000:01:00.0 VGA compatible controller: NVIDIA Corporation Device\n"
+            "0000:05:00.0 VGA compatible controller: AMD Radeon Graphics\n"
         )
+        with mock.patch.object(mux_service, "sysfs_exists", return_value=True), \
+             mock.patch.object(glob, "glob", return_value=[]), \
+             mock.patch.object(
+                 mux_service.subprocess,
+                 "check_output",
+                 return_value=lspci_output,
+             ):
+            self.assertEqual(controller.get_mode(), "hybrid")
+
+    def test_set_mode_writes_native_discrete_value(self):
+        controller = mux_service.NativeWmiMuxController()
+        with mock.patch.object(mux_service, "sysfs_exists", return_value=True), \
+             mock.patch.object(mux_service, "sysfs_write", return_value=True) as write:
+            self.assertEqual(controller.set_mode("discrete"), "OK_REBOOT_REQUIRED")
+
+        write.assert_called_once_with(mux_service.HP_WMI_GRAPHICS_MODE_PATH, "1")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_power_service.py
+++ b/tests/test_power_service.py
@@ -5,7 +5,7 @@ import unittest
 from unittest import mock
 
 
-REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(REPO_ROOT, "src", "daemon"))
 
 sys.modules.setdefault("pydbus", types.SimpleNamespace(SystemBus=lambda: None))


### PR DESCRIPTION
## Sorun neydi?

Bazı dizüstü bilgisayarlar işlemci, ekran kartı, disk, bellek ve diğer
bileşenler için çok sayıda sıcaklık değeri sunuyor. Eski OmenCtl sürümleri bu
değerlerin tamamı arasından en yükseğini kullanıyordu. Bu nedenle işlemci ve
ekran kartı serinken bile yüksek veya sıra dışı bir disk sensörü maksimum fan
modunu açabiliyordu. Koruma başladıktan sonra aynı ilgisiz sensör fanların
maksimum hızda kalmasına da neden olabiliyordu.

Güncel fan servisi fan kararlarını yalnızca işlemci ve ekran kartı sıcaklıkları
üzerinden veriyor. Bu PR, aynı hatanın ileride fark edilmeden geri gelmemesi için
bu davranışı testlerle güvence altına alıyor.

## Bu PR ne değiştiriyor?

- İşlemcinin 42°C, ekran kartının 45°C ve NVMe sensörünün 99°C olduğu gerçekçi
  bir senaryo ekliyor. NVMe değeri fan politikasını etkilememeli.
- Mevcut güvenlik eşiklerini değiştirmeden termal korumadan doğru zamanda çıkışı
  test ediyor.
- Termal koruma eşiklerine anlaşılır isimler vererek kodun amacını netleştiriyor.
- Test klasörü taşındıktan sonra bozulan import yollarını düzeltiyor.
- Eski fan ve MUX testlerini güncel servis mimarisine uyarlıyor.

## Neden daha güvenli?

İşlemci ve ekran kartı sıcaklıkları korumayı aynı eşikte etkinleştirmeye devam
ediyor. Bu değişiklik aşırı ısınma korumasını zayıflatmıyor. Yalnızca hangi
sensörlerin kullanılacağını açık hale getiriyor ve sıcaklık normale döndüğünde
önceki fan moduna geri dönülebildiğini doğruluyor.

## Testler

```text
python -m unittest discover -s tests -p 'test_*.py' -v
Ran 18 tests
OK
```

Güncel sensör denetleyicisi bir HP Victus sisteminde de kontrol edildi. İşlemci
ve ekran kartı sensörlerini seçerken hatalı maksimum fan davranışına yol açan
NVMe ikincil sensörünü fan kararına dahil etmedi.